### PR TITLE
[codex] support system proxy via environment variables

### DIFF
--- a/MCP_README.md
+++ b/MCP_README.md
@@ -137,9 +137,13 @@ go build -o mcp-server ./cmd/mcp-server
 ```bash
 export LINUXDO_USERNAME="your_username"
 export LINUXDO_PASSWORD="your_password"
+export HTTPS_PROXY="http://127.0.0.1:7890"  # 可选
+export NO_PROXY="localhost,127.0.0.1"       # 可选
 ```
 
 或者在 MCP 客户端配置文件中设置。
+
+说明：MCP Server 会自动读取 `HTTPS_PROXY` / `HTTP_PROXY`（含小写形式），`HTTPS_PROXY` 优先。代理 URL 非法时会直接启动失败，不会降级直连。
 
 ### 2. Claude Desktop 配置
 
@@ -159,7 +163,8 @@ export LINUXDO_PASSWORD="your_password"
       "args": [],
       "env": {
         "LINUXDO_USERNAME": "your_username",
-        "LINUXDO_PASSWORD": "your_password"
+        "LINUXDO_PASSWORD": "your_password",
+        "HTTPS_PROXY": "http://127.0.0.1:7890"
       }
     }
   }
@@ -178,7 +183,8 @@ export LINUXDO_PASSWORD="your_password"
       "command": "/absolute/path/to/mcp-server",
       "env": {
         "LINUXDO_USERNAME": "your_username",
-        "LINUXDO_PASSWORD": "your_password"
+        "LINUXDO_PASSWORD": "your_password",
+        "HTTPS_PROXY": "http://127.0.0.1:7890"
       }
     }
   }
@@ -202,6 +208,7 @@ export LINUXDO_PASSWORD="your_password"
 ```bash
 export LINUXDO_USERNAME="your_username"
 export LINUXDO_PASSWORD="your_password"
+export HTTPS_PROXY="http://127.0.0.1:7890"  # 可选
 ./mcp-server
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,32 @@ echo 'export LINUXDO_PASSWORD="your_password"' >> ~/.bashrc
 source ~/.bashrc
 ```
 
+### 系统代理（可选）
+
+客户端会自动读取系统代理环境变量（同时支持大写和小写）：
+
+- `HTTPS_PROXY` / `https_proxy`（访问 `https://` 目标时优先）
+- `HTTP_PROXY` / `http_proxy`（`HTTPS_PROXY` 未设置时回退）
+- `NO_PROXY` / `no_proxy`（当前仅透传环境变量，不保证与标准库完全一致）
+
+示例（Linux/macOS）：
+
+```bash
+export HTTPS_PROXY="http://127.0.0.1:7890"
+# 可选：不走代理的域名
+export NO_PROXY="localhost,127.0.0.1"
+```
+
+示例（Windows PowerShell）：
+
+```powershell
+$env:HTTPS_PROXY="http://127.0.0.1:7890"
+# 可选：不走代理的域名
+$env:NO_PROXY="localhost,127.0.0.1"
+```
+
+注意：如果代理 URL 格式非法，程序会在启动时直接报错退出，不会自动降级直连。
+
 ## 使用方法
 
 ### TUI 模式（默认）

--- a/cmd/lottery-agent/README.md
+++ b/cmd/lottery-agent/README.md
@@ -51,7 +51,11 @@ go build -o lottery-agent cmd/lottery-agent/main.go
 ```bash
 export LINUXDO_USERNAME="your_username"
 export LINUXDO_PASSWORD="your_password"
+export HTTPS_PROXY="http://127.0.0.1:7890"  # 可选
+export NO_PROXY="localhost,127.0.0.1"       # 可选
 ```
+
+说明：程序会自动读取 `HTTPS_PROXY` / `HTTP_PROXY`（含小写形式），`HTTPS_PROXY` 优先。代理 URL 非法时会直接启动失败，不会降级直连。
 
 ### 运行
 

--- a/internal/client/proxy_test.go
+++ b/internal/client/proxy_test.go
@@ -1,0 +1,139 @@
+package client
+
+import (
+	"runtime"
+	"testing"
+)
+
+func clearProxyEnv(t *testing.T) {
+	t.Helper()
+	keys := []string{
+		"HTTPS_PROXY", "https_proxy",
+		"HTTP_PROXY", "http_proxy",
+		"NO_PROXY", "no_proxy",
+	}
+	for _, key := range keys {
+		t.Setenv(key, "")
+	}
+}
+
+func TestResolveSystemProxy_HTTPSPreferred(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:8888")
+
+	proxyURL, source, err := resolveSystemProxy("https://linux.do")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if proxyURL != "http://127.0.0.1:7890" {
+		t.Fatalf("unexpected proxy url: %s", proxyURL)
+	}
+	if source != "HTTPS_PROXY" {
+		t.Fatalf("unexpected source: %s", source)
+	}
+}
+
+func TestResolveSystemProxy_FallbackToHTTPProxy(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:8888")
+
+	proxyURL, source, err := resolveSystemProxy("https://linux.do")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if proxyURL != "http://127.0.0.1:8888" {
+		t.Fatalf("unexpected proxy url: %s", proxyURL)
+	}
+	if source != "HTTP_PROXY" {
+		t.Fatalf("unexpected source: %s", source)
+	}
+}
+
+func TestResolveSystemProxy_UseLowercaseWhenUppercaseMissing(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("https_proxy", "http://127.0.0.1:7890")
+
+	proxyURL, source, err := resolveSystemProxy("https://linux.do")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if proxyURL != "http://127.0.0.1:7890" {
+		t.Fatalf("unexpected proxy url: %s", proxyURL)
+	}
+	if source != "https_proxy" && source != "HTTPS_PROXY" {
+		t.Fatalf("unexpected source: %s", source)
+	}
+}
+
+func TestResolveSystemProxy_UppercaseWinsOverLowercase(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows 环境变量名大小写不敏感，无法验证大小写优先级")
+	}
+
+	clearProxyEnv(t)
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
+	t.Setenv("https_proxy", "http://127.0.0.1:9999")
+
+	proxyURL, source, err := resolveSystemProxy("https://linux.do")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if proxyURL != "http://127.0.0.1:7890" {
+		t.Fatalf("unexpected proxy url: %s", proxyURL)
+	}
+	if source != "HTTPS_PROXY" {
+		t.Fatalf("unexpected source: %s", source)
+	}
+}
+
+func TestResolveSystemProxy_TrimWhitespace(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTPS_PROXY", "   http://127.0.0.1:7890   ")
+
+	proxyURL, source, err := resolveSystemProxy("https://linux.do")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if proxyURL != "http://127.0.0.1:7890" {
+		t.Fatalf("unexpected proxy url: %s", proxyURL)
+	}
+	if source != "HTTPS_PROXY" {
+		t.Fatalf("unexpected source: %s", source)
+	}
+}
+
+func TestResolveSystemProxy_EmptyConfig(t *testing.T) {
+	clearProxyEnv(t)
+
+	proxyURL, source, err := resolveSystemProxy("https://linux.do")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if proxyURL != "" {
+		t.Fatalf("expected empty proxy url, got: %s", proxyURL)
+	}
+	if source != "" {
+		t.Fatalf("expected empty source, got: %s", source)
+	}
+}
+
+func TestResolveSystemProxy_InvalidProxyURL(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTPS_PROXY", "://bad")
+
+	_, _, err := resolveSystemProxy("https://linux.do")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestResolveSystemProxy_InvalidBaseURL(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
+
+	_, _, err := resolveSystemProxy("linux.do")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/mcp-config.json
+++ b/mcp-config.json
@@ -5,7 +5,8 @@
       "args": [],
       "env": {
         "LINUXDO_USERNAME": "your_username",
-        "LINUXDO_PASSWORD": "your_password"
+        "LINUXDO_PASSWORD": "your_password",
+        "HTTPS_PROXY": "http://127.0.0.1:7890"
       }
     }
   }


### PR DESCRIPTION
## 问题背景
在代理网络环境下，`ldo` / `mcp-server` / `lottery-agent` 目前不会自动读取系统代理变量，导致主程序和 MCP 进程行为不一致，尤其在 MCP 由宿主进程拉起时更容易出现网络连通失败。

## 根因
HTTP 客户端初始化未接入系统代理解析逻辑，`internal/client.NewClient(...)` 直接创建 `tls-client`，没有根据 `HTTPS_PROXY`/`HTTP_PROXY` 注入代理配置。

## 修复内容
1. 在 `internal/client/client.go` 增加系统代理解析与校验：
   - `resolveSystemProxy`
   - `firstNonEmptyEnv`
   - `validateProxyURL`
   - `sanitizeProxyForLog`
2. 初始化客户端时按优先级选择代理并注入：
   - HTTPS 目标优先使用 `HTTPS_PROXY` / `https_proxy`
   - 未设置时回退到 `HTTP_PROXY` / `http_proxy`
3. 代理配置非法时直接返回错误，不降级直连（避免“看似可用但绕过代理”）。
4. 代理日志脱敏处理，避免泄露代理凭证。
5. 新增单元测试 `internal/client/proxy_test.go`，覆盖：
   - 代理优先级
   - 大小写变量兼容
   - trim 行为
   - 空配置
   - 非法 proxy URL / 非法 baseURL
   - Windows 环境变量大小写不敏感场景兼容
6. 更新文档和示例配置：
   - `README.md`
   - `MCP_README.md`
   - `cmd/lottery-agent/README.md`
   - `mcp-config.json`

## 对用户的影响
- 在设置系统代理变量后，三个入口都会自动复用代理能力。
- 若代理 URL 配置错误，程序会在初始化阶段明确失败并给出错误信息。

## 验证
已执行：

```bash
go test ./...
```

结果：通过。